### PR TITLE
update to work with stock TinyUSB

### DIFF
--- a/examples/simple_daplink/simple_daplink.ino
+++ b/examples/simple_daplink/simple_daplink.ino
@@ -92,203 +92,13 @@ uint8_t const desc_hid_report[] =
 
 };
 
-uint16_t Serial_u16[33];
-
-static inline bool isInvalidUtf8Octet(uint8_t t) {
-  // see bullets in https://tools.ietf.org/html/rfc3629#section-1
-  return (t == 0xc0) || (t == 0xC1) || ((t >= 0xF5) && (t <= 0xFF));
-}
-
-// up to 32 unicode characters (header make it 33)
-static uint16_t _desc_str[33];
-
-//
-// This function has an UNWRITTEN CONTRACT that the buffer is either:
-// 1. Pre-validated as legal UTF-8, -OR-
-// 2. has a trailing zero-value octet/byte/uint8_t  (aka null-terminated string)
-//
-// If the above are not true, this decoder may read past the end of the allocated
-// buffer, by up to three bytes.
-//
-// U+1F47F == 👿 ("IMP")
-//         == 0001_1111_0100_0111_1111 ==> requires four-byte encoding in UTF-8
-//            AABB BBBB CCCC CCDD DDDD ==> 0xF0 0x9F 0x91 0xBF
-//
-// Example sandwich and safety variables are there to cover the
-// two most-common stack layouts for declared variables, in unoptimized
-// code, so that the bytes surrounding those allocated for 'evilUTF8'
-// are guaranteed to be non-zero and valid UTF8 continuation octets.
-//     uint8_t safety1      = 0;
-//     uint8_t sandwich1[4] = { 0x81, 0x82, 0x83, 0x84 };
-//     uint8_t evilUTF8[5]  = { 0xF0, 0x9F, 0x91, 0xBF, 0xF9 };
-//     uint8_t sandwich2[4] = { 0x85, 0x86, 0x87, 0x88 };
-//     uint8_t safety2      = 0;
-//
-// NOTE: evilUTF8 could just contain a single byte 0xF9 ....
-//
-// Attempting to decode evilUTF8 will progress to whatever is next to it on the stack.
-// The above should work when optimizations are turned  
-//
-static int8_t utf8Codepoint(const uint8_t *utf8, uint32_t *codepointp)
-{
-  const uint32_t CODEPOINT_LOWEST_SURROGATE_HALF  =   0xD800;
-  const uint32_t CODEPOINT_HIGHEST_SURROGATE_HALF =   0xDFFF;
-
-  *codepointp = 0xFFFD; // always initialize output to known value ... 0xFFFD (REPLACEMENT CHARACTER) seems the natural choice
-  int codepoint;
-  int len;
-
-  // The upper bits define both the length of additional bytes for the multi-byte encoding,
-  // as well as defining how many bits of the first byte are included in the codepoint.
-  // Each additional byte starts with 0b10xxxxxx, encoding six additional bits for the codepoint.
-  //
-  // For key summary points, see:
-  // * https://tools.ietf.org/html/rfc3629#section-3
-  //
-  if (isInvalidUtf8Octet(utf8[0])) { // do not allow illegal octet sequences (e.g., 0xC0 0x80 should NOT decode to NULL)
-    return -1;
-  }
-
-  if (utf8[0] < 0x80) {                   // characters 0000 0000..0000 007F (up to  7 significant bits)
-    len = 1;
-    codepoint = utf8[0];
-  } else if ((utf8[0] & 0xe0) == 0xc0) {  // characters 0000 0080..0000 07FF (up to 11 significant bits, so first byte encodes five bits)
-    len = 2;
-    codepoint = utf8[0] & 0x1f;
-  } else if ((utf8[0] & 0xf0) == 0xe0) {  // characters 0000 8000..0000 FFFF (up to 16 significant bits, so first byte encodes four bits)
-    len = 3;
-    codepoint = utf8[0] & 0x0f;
-  } else if ((utf8[0] & 0xf8) == 0xf0) {  // characters 0001 0000..0010 FFFF (up to 21 significant bits, so first byte encodes three bits)
-    len = 4;
-    codepoint = utf8[0] & 0x07;
-  } else {                                // UTF-8 is defined to only map to Unicode -- 0x00000000..0x0010FFFF
-    // 5-byte and 6-byte sequences are not legal per RFC3629
-    return -1;
-  }
-
-  for (int i = 1; i < len; i++) {
-    if ((utf8[i] & 0xc0) != 0x80) {
-      // the additional bytes in a valid UTF-8 multi-byte encoding cannot have either of the top two bits set
-      // This is more restrictive than isInvalidUtf8Octet()
-      return -1;
-    }
-    codepoint <<= 6;             // each continuation byte adds six bits to the codepoint
-    codepoint |= utf8[i] & 0x3f; // mask off the top two continuation bits, and add the six relevant bits
-  }
-
-  // explicit validation to prevent overlong encodings
-  if (       (len == 1) && ((codepoint < 0x000000) || (codepoint > 0x00007F))) {
-    return -1;
-  } else if ((len == 2) && ((codepoint < 0x000080) || (codepoint > 0x0007FF))) {
-    return -1;
-  } else if ((len == 3) && ((codepoint < 0x000800) || (codepoint > 0x00FFFF))) {
-    return -1;
-  } else if ((len == 4) && ((codepoint < 0x010000) || (codepoint > 0x10FFFF))) {
-    // "You might expect larger code points than U+10FFFF
-    // to be expressible, but Unicode is limited in Sections 12
-    // of RFC3629 to match the limits of UTF-16." -- Wikipedia UTF-8 note
-    // See https://tools.ietf.org/html/rfc3629#section-12
-    return -1;
-  }
-
-  // high and low surrogate halves (U+D800 through U+DFFF) used by UTF-16 are
-  // not legal Unicode values ... see RFC 3629.
-  if ((codepoint >= CODEPOINT_LOWEST_SURROGATE_HALF) && (codepoint <= CODEPOINT_HIGHEST_SURROGATE_HALF)) {
-    return -1;
-  }
-
-  *codepointp = codepoint;
-  return len;
-}
-
-
-static int strcpy_utf16(const char *s, uint16_t *buf, int bufsize)
-{
-  int i = 0;
-  int buflen = 0;
-
-  while (s[i] != 0) {
-    uint32_t codepoint;
-    int8_t utf8len = utf8Codepoint((const uint8_t *)s + i, &codepoint);
-
-    if (utf8len < 0) {
-      // Invalid utf8 sequence, skip it
-      i++;
-      continue;
-    }
-
-    i += utf8len;
-
-    if (codepoint <= 0xffff) {
-      if (buflen == bufsize)
-        break;
-
-      buf[buflen++] = codepoint;
-
-    } else {
-      if (buflen + 1 >= bufsize)
-        break;
-
-      // Surrogate pair
-      codepoint -= 0x10000;
-      buf[buflen++] = (codepoint >> 10) + 0xd800;
-      buf[buflen++] = (codepoint & 0x3ff) + 0xdc00;
-    }
-  }
-
-  return buflen;
-}
-
-
-// Invoked when received GET STRING DESCRIPTOR request
-// Application return pointer to descriptor, whose contents must exist long enough for transfer to complete
-// Note: the 0xEE index string is a Microsoft OS 1.0 Descriptors.
-// https://docs.microsoft.com/en-us/windows-hardware/drivers/usbcon/microsoft-defined-usb-descriptors
-const uint16_t * tud_descriptor_string_cb(uint8_t index, uint16_t langid)
-{
-  (void) langid;
-
-  uint8_t chr_count;
-
-  switch (index)
-  {
-    case 0:
-      _desc_str[1] = USBDevice.getLanguageDescriptor();
-      chr_count = 1;
-    break;
-    case 1:
-      chr_count = strcpy_utf16(USBDevice.getManufacturerDescriptor(), _desc_str + 1, 32);
-    break;
-
-    case 2:
-      chr_count = strcpy_utf16(USBDevice.getProductDescriptor(), _desc_str + 1, 32);
-    break;
-
-    case 3:
-      // serial Number
-      chr_count = USBDevice.getSerialDescriptor(_desc_str+1);
-    break;
-    case 4:
-      // interface name
-      chr_count = strcpy_utf16("CMSIS-DAP", _desc_str + 1, 32);
-    break;
-    default: return NULL;
-  }
-
-  // first byte is length (including header), second byte is string type
-  _desc_str[0] = (TUSB_DESC_STRING << 8 ) | (2*chr_count + 2);
-
-  return _desc_str;
-}
-
-
-
-
 void setup() {
+    USBDevice.setProductDescriptor("CMSIS-DAP");
+
     usb_hid.enableOutEndpoint(true);
     usb_hid.setPollInterval(2);
     usb_hid.setBootProtocol(0);
-    USBDevice.setProductDescriptor("CMSIS-DAP");
+    usb_hid.setStringDescriptor("CMSIS-DAP");
     usb_hid.setReportDescriptor(desc_hid_report, sizeof(desc_hid_report));
     usb_hid.setReportCallback(get_report_callback, set_report_callback);
     
@@ -296,9 +106,8 @@ void setup() {
     
     pinMode(LED_BUILTIN, OUTPUT);
     
-    Serial.begin(115200);
-    baud = Serial.getBaud();
-    old_baud = baud;
+    baud = old_baud = 115200;
+    Serial.begin(baud);
     SerialTTL.begin(baud);
 
     // wait until device mounted
@@ -311,16 +120,14 @@ void setup() {
     USB_ResponseIdle = 1;
     free_count = FREE_COUNT_INIT;
     send_count = SEND_COUNT_INIT;
-
-    USBDevice.getSerialDescriptor(Serial_u16);
-
 }
 
 
 void loop() {
   // put your main code here, to run repeatedly:
-  baud = Serial.getBaud();
+  baud = Serial.baud();
   if (baud != old_baud) {
+    SerialTTL.end();
     SerialTTL.begin(baud);
     while (!SerialTTL);
     old_baud = baud;
@@ -337,6 +144,7 @@ void loop() {
     Serial.write(c);
   }
 }
+
 void hid_send_packet()
 {
     if (send_count) {

--- a/examples/simple_daplink/simple_daplink.ino
+++ b/examples/simple_daplink/simple_daplink.ino
@@ -127,7 +127,6 @@ void loop() {
   // put your main code here, to run repeatedly:
   baud = Serial.baud();
   if (baud != old_baud) {
-    SerialTTL.end();
     SerialTTL.begin(baud);
     while (!SerialTTL);
     old_baud = baud;

--- a/src/DAP.cpp
+++ b/src/DAP.cpp
@@ -81,7 +81,6 @@ const char TargetDeviceVendor [] = TARGET_DEVICE_VENDOR;
 const char TargetDeviceName   [] = TARGET_DEVICE_NAME;
 #endif
 
-extern uint16_t Serial_u16[33];
 // Get DAP Information
 //   id:      info identifier
 //   info:    pointer to info data
@@ -104,8 +103,7 @@ static uint8_t DAP_Info(uint8_t id, uint8_t *info) {
       break;
     case DAP_ID_SER_NUM:
 #ifdef DAP_SER_NUM
-      memcpy(info, &Serial_u16[0], 32);
-      length = 32;
+      length = USBDevice.getSerialDescriptor((uint16_t*) info);
 #endif
       break;
     case DAP_ID_FW_VER:

--- a/src/DAP_config.h
+++ b/src/DAP_config.h
@@ -183,6 +183,16 @@ Provides definitions about:
 #define PIN_LED_CONNECTED PIN_LED_TXL
 #define PIN_LED_RUNNING   PIN_LED_RXL
 
+#else
+
+#define PIN_SWDIO         A0
+#define PIN_SWCLK         A1
+#define PIN_TDO           A3
+#define PIN_TDI           A4
+#define PIN_nRESET        A2
+#define PIN_LED_CONNECTED LED_BUILTIN
+#define PIN_LED_RUNNING   LED_BUILTIN
+
 #endif 
 //**************************************************************************************************
 /**

--- a/src/board.cpp
+++ b/src/board.cpp
@@ -102,6 +102,11 @@
 #define BOARD_ID        {1, 1, 1, 1}
 #define BOARD_SECRET    {1, 1, 1, 1, 1, 1, 1, 1, 1}
 
+#else // default for all other boards
+
+#define BOARD_ID        {1, 1, 1, 1}
+#define BOARD_SECRET    {1, 1, 1, 1, 1, 1, 1, 1, 1}
+
 #endif
 
 #if !defined(BOARD_SECRET) || !defined(BOARD_ID)


### PR DESCRIPTION
Hi there,

Thank you very much for the library, @ladyada and me found this library is very interesting, and would like to try it out on our M0 board. However, this repo uses a modified version of TinyUSB. I have looked at the modification and your previous closed PR to TinyUSB, and update the usb library  to support those modification in a more user friendly. 

**What this PR does**

- Allows this library to use stock TinyUSB (without modification) making it portable and less work to maintain
- Add `#else#` as default config for board.cpp (most maker won't bother with this file)
- Add `#else#` pin config for DAP_config.h . I am not entirely sure, but in most of Arduino board the pin A0, A1, A2 is very common (more common than D0,D1,D2) maybe we could use this. 

**What this PR need**

You need to update your BSP core to use latest  (https://github.com/adafruit/Adafruit_TinyUSB_ArduinoCore/commit/e7b892095f2bb5d8bef6a748238369bdd268ed5e) which support 
- setStringDescriptor() for any class interface
- CDC baud()  ( this name is preferred to stay compatible with Arduino upstream CDC https://github.com/arduino/ArduinoCore-samd/blob/master/cores/arduino/USB/CDC.h#L121)

Since I haven't tested it on actual hardware yet (tomorrow or so), I make it as draft PR to see if there is any review/suggestion you would like me to change.